### PR TITLE
Fix eslint config for new CLI

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,7 @@
+const { FlatCompat } = require('@eslint/eslintrc');
+const compat = new FlatCompat({ baseDirectory: __dirname, resolvePluginsRelativeTo: __dirname });
+const eslintrc = require('./.eslintrc.js');
+delete eslintrc.root;
+module.exports = [
+  ...compat.config(eslintrc),
+];

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "build": "tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
-    "lint": "eslint nodes credentials package.json",
-    "lintfix": "eslint nodes credentials package.json --fix",
+    "lint": "eslint --ext .ts nodes credentials package.json",
+    "lintfix": "eslint --ext .ts nodes credentials package.json --fix",
     "prepublishOnly": "npm build && npm lint -c .eslintrc.prepublish.js nodes credentials package.json"
   },
   "files": [


### PR DESCRIPTION
## Summary
- add `eslint.config.js` that converts existing `.eslintrc.js` using `FlatCompat`
- update lint scripts to look for `.ts` files

## Testing
- `npm run lint` *(fails: plugin not installed)*