### PR TITLE
Fix lint script globs

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "build": "tsc && gulp build:icons",
     "dev": "tsc --watch",
     "format": "prettier nodes credentials --write",
-    "lint": "eslint --ext .ts nodes credentials package.json",
+    "lint": "eslint \"nodes/**/*.{ts,tsx}\" \"credentials/**/*.{ts,tsx}\" package.json",
     "lintfix": "eslint --ext .ts nodes credentials package.json --fix",
     "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json"
   },


### PR DESCRIPTION
## Summary
- update `lint` script to directly specify globs for nodes and credentials

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/eslintrc')*