### PR TITLE
Add basic node tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "format": "prettier nodes credentials --write",
     "lint": "eslint \"nodes/**/*.{ts,tsx}\" package.json",
     "lintfix": "eslint --ext .ts nodes credentials package.json --fix",
-    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json"
+    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json",
+    "test": "node --test"
   },
   "files": [
     "dist"

--- a/test/gitExtended.test.js
+++ b/test/gitExtended.test.js
@@ -1,0 +1,41 @@
+const { test } = require('node:test');
+const assert = require('node:assert');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { GitExtended } = require('../dist/nodes/GitExtended/GitExtended.node.js');
+
+class TestContext {
+  constructor(parameters) {
+    this.parameters = parameters;
+  }
+  getInputData() {
+    return [{ json: {} }];
+  }
+  getNodeParameter(name) {
+    return this.parameters[name];
+  }
+  getNode() {
+    return { name: 'GitExtended' };
+  }
+  continueOnFail() {
+    return false;
+  }
+}
+
+test('init operation creates git repository', async () => {
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-test-'));
+  const node = new GitExtended();
+  const context = new TestContext({ operation: 'init', repoPath: tempDir });
+  await node.execute.call(context);
+  assert.ok(fs.existsSync(path.join(tempDir, '.git')));
+  fs.rmSync(tempDir, { recursive: true, force: true });
+});
+
+test('unsupported operation throws error', async () => {
+  const node = new GitExtended();
+  const context = new TestContext({ operation: 'unknown', repoPath: '.' });
+  await assert.rejects(async () => {
+    await node.execute.call(context);
+  }, /Unsupported operation/);
+});


### PR DESCRIPTION
## Summary
- add simple tests for the GitExtended node using Node's built-in test runner
- add npm script to run tests

## Testing
- `npm test`