### PR TITLE
Fix prepublish script for empty credentials directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "format": "prettier nodes credentials --write",
     "lint": "eslint \"nodes/**/*.{ts,tsx}\" package.json",
     "lintfix": "eslint --ext .ts nodes credentials package.json --fix",
-    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes credentials package.json",
+    "prepublishOnly": "npm run build && npm run lint -c .eslintrc.prepublish.js nodes package.json",
     "test": "node --test"
   },
   "files": [


### PR DESCRIPTION
## Summary
- skip linting the empty `credentials` directory during prepublish

## Testing
- `npm test`
- `npm run lint`
- `npm run build`
- `npm run -s prepublishOnly`
