### PR TITLE
Add repository path parameter to all git operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ These are the basic steps for working with the starter. For detailed guidance on
 
 This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout` and `merge`.
 
+Every operation requires a **Repository Path** parameter that defines the directory from which the Git command is executed. For `clone`, the repository will be created inside this directory.
+
 ### Running Git commands
 
 The node relies on the `git` binary available on the machine running n8n. Make sure `git` is installed and accessible from the command line.

--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -88,12 +88,8 @@ export class GitExtended implements INodeType {
         name: 'repoPath',
         type: 'string',
         default: '.',
-        description: 'Filesystem path to the git repository',
-        displayOptions: {
-          hide: {
-            operation: ['clone'],
-          },
-        },
+        description:
+          'Filesystem path to run the Git command from. For clone, the repository will be created inside this path.',
       },
       {
         displayName: 'Repository URL',
@@ -192,15 +188,14 @@ export class GitExtended implements INodeType {
     for (let i = 0; i < items.length; i++) {
       try {
         const operation = this.getNodeParameter('operation', i) as string;
-        let repoPath = '';
+        const repoPath = this.getNodeParameter('repoPath', i) as string;
         let command = '';
 
         if (operation === 'clone') {
           const repoUrl = this.getNodeParameter('repoUrl', i) as string;
           const targetPath = this.getNodeParameter('targetPath', i) as string;
-          command = `git clone ${repoUrl} "${targetPath}"`;
+          command = `git -C "${repoPath}" clone ${repoUrl} "${targetPath}"`;
         } else {
-          repoPath = this.getNodeParameter('repoPath', i) as string;
 
           if (operation === 'init') {
             command = `git -C "${repoPath}" init`;


### PR DESCRIPTION
## Summary
- always show the `Repository Path` parameter
- use it for the clone command
- document the requirement in the README
- test clone operation using repository path
- fix git clone test by configuring user name and email

## Testing
- `npm run lint`
- `npm test`
