### PR TITLE
Add icon for Git Extended node

### DIFF
--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -9,6 +9,7 @@ export class GitExtended implements INodeType {
   description: INodeTypeDescription = {
     displayName: 'Git Extended',
     name: 'gitExtended',
+    icon: 'file:gitExtended.svg',
     group: ['transform'],
     version: 1,
     subtitle: '={{$parameter["operation"]}}',

--- a/nodes/GitExtended/gitExtended.svg
+++ b/nodes/GitExtended/gitExtended.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#F05133"/>
+  <path d="M30 20 L70 50 L30 80" fill="none" stroke="#ffffff" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="30" cy="20" r="5" fill="#ffffff"/>
+  <circle cx="70" cy="50" r="5" fill="#ffffff"/>
+  <circle cx="30" cy="80" r="5" fill="#ffffff"/>
+</svg>


### PR DESCRIPTION
## Summary
- add `gitExtended.svg` icon
- reference the icon in node defaults
- rebuild TypeScript and run tests

## Testing
- `npm run build`
- `npm test`
