### PR TITLE
Add patch apply support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,11 @@ These are the basic steps for working with the starter. For detailed guidance on
 
 ## Git Extended node
 
-This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout` and `merge`.
+This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout`, `merge` and `applyPatch`.
 
 Every operation requires a **Repository Path** parameter that defines the directory from which the Git command is executed. For `clone`, the repository will be created inside this directory.
+
+The `applyPatch` operation uses `git apply` to apply a patch file. You can provide the patch text directly or specify a path to a patch file. Enable the *Binary* option when applying binary patches.
 
 ### Running Git commands
 

--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -1,6 +1,9 @@
 import type { IExecuteFunctions, INodeExecutionData, INodeType, INodeTypeDescription } from 'n8n-workflow';
 import { NodeConnectionType, NodeOperationError } from 'n8n-workflow';
 import { exec as execCallback } from 'child_process';
+import { promises as fs } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { promisify } from 'util';
 
 const exec = promisify(execCallback);
@@ -30,6 +33,11 @@ export class GitExtended implements INodeType {
             name: 'Add',
             value: 'add',
             action: 'Add files',
+          },
+          {
+            name: 'Apply Patch',
+            value: 'applyPatch',
+            action: 'Apply patch',
           },
           {
             name: 'Checkout',
@@ -167,6 +175,66 @@ export class GitExtended implements INodeType {
         },
       },
       {
+        displayName: 'Patch Input',
+        name: 'patchInput',
+        type: 'options',
+        options: [
+          {
+            name: 'Text',
+            value: 'text',
+          },
+          {
+            name: 'File',
+            value: 'file',
+          },
+        ],
+        default: 'text',
+        displayOptions: {
+          show: {
+            operation: ['applyPatch'],
+          },
+        },
+      },
+      {
+        displayName: 'Patch Text',
+        name: 'patchText',
+        type: 'string',
+        typeOptions: {
+          rows: 5,
+        },
+        default: '',
+        displayOptions: {
+          show: {
+            operation: ['applyPatch'],
+            patchInput: ['text'],
+          },
+        },
+      },
+      {
+        displayName: 'Patch File Path',
+        name: 'patchFile',
+        type: 'string',
+        default: '',
+        displayOptions: {
+          show: {
+            operation: ['applyPatch'],
+            patchInput: ['file'],
+          },
+        },
+      },
+      {
+        displayName: 'Binary',
+        name: 'binary',
+        type: 'boolean',
+        default: false,
+        description: 'Whether to apply the patch in binary mode',
+        displayOptions: {
+          show: {
+            operation: ['applyPatch'],
+          },
+        },
+      },
+      {
         displayName: 'Target',
         name: 'target',
         type: 'string',
@@ -191,6 +259,7 @@ export class GitExtended implements INodeType {
         const operation = this.getNodeParameter('operation', i) as string;
         const repoPath = this.getNodeParameter('repoPath', i) as string;
         let command = '';
+        let tempFile: string | undefined;
 
         if (operation === 'clone') {
           const repoUrl = this.getNodeParameter('repoUrl', i) as string;
@@ -231,12 +300,26 @@ export class GitExtended implements INodeType {
           } else if (operation === 'merge') {
             const target = this.getNodeParameter('target', i) as string;
             command = `git -C "${repoPath}" merge ${target}`;
+          } else if (operation === 'applyPatch') {
+            const patchInput = this.getNodeParameter('patchInput', i) as string;
+            const binary = this.getNodeParameter('binary', i) as boolean;
+            let patchFile: string;
+            if (patchInput === 'text') {
+              const patchText = this.getNodeParameter('patchText', i) as string;
+              tempFile = join(tmpdir(), `patch-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+              await fs.writeFile(tempFile, patchText);
+              patchFile = tempFile;
+            } else {
+              patchFile = this.getNodeParameter('patchFile', i) as string;
+            }
+            command = `git -C "${repoPath}" apply${binary ? ' --binary' : ''} "${patchFile}"`;
           } else {
             throw new NodeOperationError(this.getNode(), `Unsupported operation ${operation}`, { itemIndex: i });
           }
         }
 
         const { stdout, stderr } = await exec(command);
+        if (tempFile) await fs.unlink(tempFile);
         returnData.push({ json: { stdout: stdout.trim(), stderr: stderr.trim() } });
       } catch (error) {
         if (this.continueOnFail()) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.1",
       "license": "MIT",
       "devDependencies": {
-        "@types/node": "^20.17.47",
+        "@types/node": "^20.17.50",
         "@typescript-eslint/parser": "~8.32.0",
         "eslint": "^8.57.0",
         "eslint-plugin-n8n-nodes-base": "^1.16.3",
@@ -335,9 +335,9 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.17.47",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.47.tgz",
-      "integrity": "sha512-3dLX0Upo1v7RvUimvxLeXqwrfyKxUINk0EAM83swP2mlSUcwV73sZy8XhNz8bcZ3VbsfQyC/y6jRdL5tgCNpDQ==",
+      "version": "20.17.50",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.50.tgz",
+      "integrity": "sha512-Mxiq0ULv/zo1OzOhwPqOA13I81CV/W3nvd3ChtQZRT5Cwz3cr0FKo/wMSsbTqL3EXpaBAEQhva2B8ByRkOIh9A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ]
   },
   "devDependencies": {
-    "@types/node": "^20.17.47",
+    "@types/node": "^20.17.50",
     "@typescript-eslint/parser": "~8.32.0",
     "eslint": "^8.57.0",
     "eslint-plugin-n8n-nodes-base": "^1.16.3",


### PR DESCRIPTION
## Summary
- add new operation for applying git patches from text or file
- document applyPatch operation
- fix ordering of operations and lint issues

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
