### PR TITLE
Fix lint ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These are the basic steps for working with the starter. For detailed guidance on
 
 ## Git Extended node
 
-This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout`, `merge` and `applyPatch`.
+This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, and `commits`.
 
 Every operation requires a **Repository Path** parameter that defines the directory from which the Git command is executed. For `clone`, the repository will be created inside this directory.
 

--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -40,6 +40,11 @@ export class GitExtended implements INodeType {
             action: 'Apply patch',
           },
           {
+            name: 'Branches',
+            value: 'branches',
+            action: 'List branches',
+          },
+          {
             name: 'Checkout',
             value: 'checkout',
             action: 'Checkout',
@@ -53,6 +58,11 @@ export class GitExtended implements INodeType {
             name: 'Commit',
             value: 'commit',
             action: 'Create commit',
+          },
+          {
+            name: 'Commits',
+            value: 'commits',
+            action: 'List commits',
           },
           {
             name: 'Init',
@@ -287,6 +297,10 @@ export class GitExtended implements INodeType {
             command = `git -C "${repoPath}" pull`;
             if (remote) command += ` ${remote}`;
             if (branch) command += ` ${branch}`;
+          } else if (operation === 'branches') {
+            command = `git -C "${repoPath}" branch`;
+          } else if (operation === 'commits') {
+            command = `git -C "${repoPath}" log --oneline`;
           } else if (operation === 'status') {
             command = `git -C "${repoPath}" status`;
           } else if (operation === 'log') {

--- a/test/gitExtended.test.js
+++ b/test/gitExtended.test.js
@@ -71,3 +71,51 @@ test('clone operation clones repository', async () => {
   fs.rmSync(sourceDir, { recursive: true, force: true });
   fs.rmSync(cloneDir, { recursive: true, force: true });
 });
+
+test('branches operation lists branches', async () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-branches-'));
+  require('child_process').execSync('git init', { cwd: repoDir });
+  require('child_process').execSync('git config user.email "test@example.com"', {
+    cwd: repoDir,
+  });
+  require('child_process').execSync('git config user.name "Test"', {
+    cwd: repoDir,
+  });
+  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+  require('child_process').execSync('git add README.md', { cwd: repoDir });
+  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+  require('child_process').execSync('git branch feature', { cwd: repoDir });
+
+  const node = new GitExtended();
+  const context = new TestContext({ operation: 'branches', repoPath: repoDir });
+  const result = await node.execute.call(context);
+  const output = result[0][0].json.stdout;
+  assert.ok(output.includes('feature'));
+
+  fs.rmSync(repoDir, { recursive: true, force: true });
+});
+
+test('commits operation lists commits', async () => {
+  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-commits-'));
+  require('child_process').execSync('git init', { cwd: repoDir });
+  require('child_process').execSync('git config user.email "test@example.com"', {
+    cwd: repoDir,
+  });
+  require('child_process').execSync('git config user.name "Test"', {
+    cwd: repoDir,
+  });
+  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+  require('child_process').execSync('git add README.md', { cwd: repoDir });
+  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+  fs.writeFileSync(path.join(repoDir, 'file.txt'), 'second');
+  require('child_process').execSync('git add file.txt', { cwd: repoDir });
+  require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
+
+  const node = new GitExtended();
+  const context = new TestContext({ operation: 'commits', repoPath: repoDir });
+  const result = await node.execute.call(context);
+  const output = result[0][0].json.stdout;
+  assert.ok(output.includes('second'));
+
+  fs.rmSync(repoDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- sort operation list alphabetically
- document the new `branches` and `commits` actions

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
