### PR TITLE
Add more git commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These are the basic steps for working with the starter. For detailed guidance on
 
 ## Git Extended node
 
-This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, `createBranch`, `deleteBranch`, `renameBranch`, and `commits`.
+This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, `createBranch`, `deleteBranch`, `renameBranch`, `commits`, `fetch`, `rebase`, `cherryPick`, `revert`, `reset`, `stash`, and `tag`.
 
 Every operation requires a **Repository Path** parameter that defines the directory from which the Git command is executed. For `clone`, the repository will be created inside this directory.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "node": ">=20.15"
       },
       "peerDependencies": {
-        "n8n-workflow": "*"
+        "n8n-workflow": "^1.82.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {

--- a/package.json
+++ b/package.json
@@ -50,6 +50,6 @@
     "typescript": "^5.8.2"
   },
   "peerDependencies": {
-    "n8n-workflow": "*"
+    "n8n-workflow": "^1.82.0"
   }
 }


### PR DESCRIPTION
## Summary
- extend GitExtended operations
- support additional git commands like fetch, rebase, cherry-pick and others
- document new operations
- test new git commands
- fix option sort order

## Testing
- `npm run build`
- `npm test`
- `npm run lint`
