### PR TITLE
Add git reset operation without commit

### DIFF
--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -15,30 +15,30 @@ import { promisify } from 'util';
 const exec = promisify(execCallback);
 
 enum Operation {
-        Add = 'add',
-        ApplyPatch = 'applyPatch',
-        CreateBranch = 'createBranch',
-        DeleteBranch = 'deleteBranch',
-        Branches = 'branches',
-        Checkout = 'checkout',
-        Clone = 'clone',
-        Commit = 'commit',
-        Commits = 'commits',
-        RenameBranch = 'renameBranch',
-        Init = 'init',
-        Log = 'log',
-        Merge = 'merge',
-        CherryPick = 'cherryPick',
-        Fetch = 'fetch',
-        Rebase = 'rebase',
-        Reset = 'reset',
-        Revert = 'revert',
-        Stash = 'stash',
-        Tag = 'tag',
-        Pull = 'pull',
-        Push = 'push',
-        Status = 'status',
-        Switch = 'switch',
+	Add = 'add',
+	ApplyPatch = 'applyPatch',
+	CreateBranch = 'createBranch',
+	DeleteBranch = 'deleteBranch',
+	Branches = 'branches',
+	Checkout = 'checkout',
+	Clone = 'clone',
+	Commit = 'commit',
+	Commits = 'commits',
+	RenameBranch = 'renameBranch',
+	Init = 'init',
+	Log = 'log',
+	Merge = 'merge',
+	CherryPick = 'cherryPick',
+	Fetch = 'fetch',
+	Rebase = 'rebase',
+	Reset = 'reset',
+	Revert = 'revert',
+	Stash = 'stash',
+	Tag = 'tag',
+	Pull = 'pull',
+	Push = 'push',
+	Status = 'status',
+	Switch = 'switch',
 }
 
 type CommandResult = { command: string; tempFile?: string };
@@ -61,7 +61,10 @@ const commandMap: Record<Operation, CommandBuilder> = {
 				url.password = creds.password as string;
 				repoUrl = url.toString();
 			} catch (error) {
-                                throw new NodeOperationError(this.getNode(), `Failed to parse the repository URL: ${repoUrl}. Error: ${(error as Error).message}`);
+				throw new NodeOperationError(
+					this.getNode(),
+					`Failed to parse the repository URL: ${repoUrl}. Error: ${(error as Error).message}`,
+				);
 			}
 		}
 		const targetPath = this.getNodeParameter('targetPath', index) as string;
@@ -96,82 +99,89 @@ const commandMap: Record<Operation, CommandBuilder> = {
 		if (branch) cmd += ` ${branch}`;
 		return { command: cmd };
 	},
-        async [Operation.Branches](_index, repoPath) {
-                return { command: `git -C "${repoPath}" branch` };
-        },
-        async [Operation.CreateBranch](index, repoPath) {
-                const branchName = this.getNodeParameter('branchName', index) as string;
-                return { command: `git -C "${repoPath}" branch ${branchName}` };
-        },
-        async [Operation.DeleteBranch](index, repoPath) {
-                const branchName = this.getNodeParameter('branchName', index) as string;
-                return { command: `git -C "${repoPath}" branch -d ${branchName}` };
-        },
-        async [Operation.RenameBranch](index, repoPath) {
-                const currentName = this.getNodeParameter('currentName', index) as string;
-                const newName = this.getNodeParameter('newName', index) as string;
-                return { command: `git -C "${repoPath}" branch -m ${currentName} ${newName}` };
-        },
-        async [Operation.Commits](_index, repoPath) {
-                return { command: `git -C "${repoPath}" log --oneline` };
-        },
+	async [Operation.Branches](_index, repoPath) {
+		return { command: `git -C "${repoPath}" branch` };
+	},
+	async [Operation.CreateBranch](index, repoPath) {
+		const branchName = this.getNodeParameter('branchName', index) as string;
+		return { command: `git -C "${repoPath}" branch ${branchName}` };
+	},
+	async [Operation.DeleteBranch](index, repoPath) {
+		const branchName = this.getNodeParameter('branchName', index) as string;
+		return { command: `git -C "${repoPath}" branch -d ${branchName}` };
+	},
+	async [Operation.RenameBranch](index, repoPath) {
+		const currentName = this.getNodeParameter('currentName', index) as string;
+		const newName = this.getNodeParameter('newName', index) as string;
+		return { command: `git -C "${repoPath}" branch -m ${currentName} ${newName}` };
+	},
+	async [Operation.Commits](_index, repoPath) {
+		return { command: `git -C "${repoPath}" log --oneline` };
+	},
 	async [Operation.Status](_index, repoPath) {
 		return { command: `git -C "${repoPath}" status` };
 	},
 	async [Operation.Log](_index, repoPath) {
 		return { command: `git -C "${repoPath}" log` };
 	},
-        async [Operation.Switch](index, repoPath) {
-                const target = this.getNodeParameter('target', index) as string;
-                const create = this.getNodeParameter('create', index, false) as boolean;
-                return { command: `git -C "${repoPath}" switch${create ? ' -c' : ''} ${target}` };
-        },
+	async [Operation.Switch](index, repoPath) {
+		const target = this.getNodeParameter('target', index) as string;
+		const create = this.getNodeParameter('create', index, false) as boolean;
+		return { command: `git -C "${repoPath}" switch${create ? ' -c' : ''} ${target}` };
+	},
 	async [Operation.Checkout](index, repoPath) {
 		const target = this.getNodeParameter('target', index) as string;
 		return { command: `git -C "${repoPath}" checkout ${target}` };
 	},
-        async [Operation.Merge](index, repoPath) {
-                const target = this.getNodeParameter('target', index) as string;
-                return { command: `git -C "${repoPath}" merge ${target}` };
-        },
-        async [Operation.Fetch](index, repoPath) {
-                const remote = this.getNodeParameter('remote', index) as string;
-                const branch = this.getNodeParameter('branch', index) as string;
-                let cmd = `git -C "${repoPath}" fetch`;
-                if (remote) cmd += ` ${remote}`;
-                if (branch) cmd += ` ${branch}`;
-                return { command: cmd };
-        },
-        async [Operation.Rebase](index, repoPath) {
-                const upstream = this.getNodeParameter('upstream', index) as string;
-                return { command: `git -C "${repoPath}" rebase ${upstream}` };
-        },
-        async [Operation.CherryPick](index, repoPath) {
-                const commit = this.getNodeParameter('commit', index) as string;
-                return { command: `git -C "${repoPath}" cherry-pick ${commit}` };
-        },
-        async [Operation.Revert](index, repoPath) {
-                const commit = this.getNodeParameter('commit', index) as string;
-                return { command: `git -C "${repoPath}" revert ${commit} --no-edit` };
-        },
-        async [Operation.Reset](index, repoPath) {
-                const commit = this.getNodeParameter('commit', index) as string;
-                return { command: `git -C "${repoPath}" reset --hard ${commit}` };
-        },
-        async [Operation.Stash](_index, repoPath) {
-                return { command: `git -C "${repoPath}" stash` };
-        },
-        async [Operation.Tag](index, repoPath) {
-                const tagName = this.getNodeParameter('tagName', index) as string;
-                const tagCommit = this.getNodeParameter('tagCommit', index) as string;
-                let cmd = `git -C "${repoPath}" tag ${tagName}`;
-                if (tagCommit) cmd += ` ${tagCommit}`;
-                return { command: cmd };
-        },
-        async [Operation.ApplyPatch](index, repoPath) {
-                const patchInput = this.getNodeParameter('patchInput', index) as string;
-                const binary = this.getNodeParameter('binary', index) as boolean;
-                let patchFile: string;
+	async [Operation.Merge](index, repoPath) {
+		const target = this.getNodeParameter('target', index) as string;
+		return { command: `git -C "${repoPath}" merge ${target}` };
+	},
+	async [Operation.Fetch](index, repoPath) {
+		const remote = this.getNodeParameter('remote', index) as string;
+		const branch = this.getNodeParameter('branch', index) as string;
+		let cmd = `git -C "${repoPath}" fetch`;
+		if (remote) cmd += ` ${remote}`;
+		if (branch) cmd += ` ${branch}`;
+		return { command: cmd };
+	},
+	async [Operation.Rebase](index, repoPath) {
+		const upstream = this.getNodeParameter('upstream', index) as string;
+		return { command: `git -C "${repoPath}" rebase ${upstream}` };
+	},
+	async [Operation.CherryPick](index, repoPath) {
+		const commit = this.getNodeParameter('commit', index) as string;
+		if (!commit) {
+			throw new NodeOperationError(this.getNode(), 'Commit ID is required');
+		}
+		return { command: `git -C "${repoPath}" cherry-pick ${commit}` };
+	},
+	async [Operation.Revert](index, repoPath) {
+		const commit = this.getNodeParameter('commit', index) as string;
+		if (!commit) {
+			throw new NodeOperationError(this.getNode(), 'Commit ID is required');
+		}
+		return { command: `git -C "${repoPath}" revert ${commit} --no-edit` };
+	},
+	async [Operation.Reset](index, repoPath) {
+		const commit = this.getNodeParameter('commit', index, '') as string;
+		const commitArg = commit ? ` ${commit}` : '';
+		return { command: `git -C "${repoPath}" reset --hard${commitArg}` };
+	},
+	async [Operation.Stash](_index, repoPath) {
+		return { command: `git -C "${repoPath}" stash` };
+	},
+	async [Operation.Tag](index, repoPath) {
+		const tagName = this.getNodeParameter('tagName', index) as string;
+		const tagCommit = this.getNodeParameter('tagCommit', index) as string;
+		let cmd = `git -C "${repoPath}" tag ${tagName}`;
+		if (tagCommit) cmd += ` ${tagCommit}`;
+		return { command: cmd };
+	},
+	async [Operation.ApplyPatch](index, repoPath) {
+		const patchInput = this.getNodeParameter('patchInput', index) as string;
+		const binary = this.getNodeParameter('binary', index) as boolean;
+		let patchFile: string;
 		let tempFile: string | undefined;
 		if (patchInput === 'text') {
 			const patchText = this.getNodeParameter('patchText', index) as string;
@@ -217,130 +227,130 @@ export class GitExtended implements INodeType {
 				name: 'operation',
 				type: 'options',
 				noDataExpression: true,
-                                options: [
-                                        {
-                                                name: 'Add',
-                                                value: 'add',
-                                                action: 'Add files',
-                                        },
-                                        {
-                                                name: 'Apply Patch',
-                                                value: 'applyPatch',
-                                                action: 'Apply patch',
-                                        },
-                                        {
-                                                name: 'Branches',
-                                                value: 'branches',
-                                                action: 'List branches',
-                                        },
-                                        {
-                                                name: 'Checkout',
-                                                value: 'checkout',
-                                                action: 'Checkout',
-                                        },
-                                        {
-                                                name: 'Cherry Pick',
-                                                value: 'cherryPick',
-                                                action: 'Cherry pick commit',
-                                        },
-                                        {
-                                                name: 'Clone',
-                                                value: 'clone',
-                                                action: 'Clone repository',
-                                        },
-                                        {
-                                                name: 'Commit',
-                                                value: 'commit',
-                                                action: 'Create commit',
-                                        },
-                                        {
-                                                name: 'Commits',
-                                                value: 'commits',
-                                                action: 'List commits',
-                                        },
-                                        {
-                                                name: 'Create Branch',
-                                                value: 'createBranch',
-                                                action: 'Create branch',
-                                        },
-                                        {
-                                                name: 'Delete Branch',
-                                                value: 'deleteBranch',
-                                                action: 'Delete branch',
-                                        },
-                                        {
-                                                name: 'Fetch',
-                                                value: 'fetch',
-                                                action: 'Fetch from remote',
-                                        },
-                                        {
-                                                name: 'Init',
-                                                value: 'init',
-                                                action: 'Initialize repository',
-                                        },
-                                        {
-                                                name: 'Log',
-                                                value: 'log',
-                                                action: 'Show log',
-                                        },
-                                        {
-                                                name: 'Merge',
-                                                value: 'merge',
-                                                action: 'Merge branch',
-                                        },
-                                        {
-                                                name: 'Pull',
-                                                value: 'pull',
-                                                action: 'Pull branch',
-                                        },
-                                        {
-                                                name: 'Push',
-                                                value: 'push',
-                                                action: 'Push branch',
-                                        },
-                                        {
-                                                name: 'Rebase',
-                                                value: 'rebase',
-                                                action: 'Rebase branch',
-                                        },
-                                        {
-                                                name: 'Rename Branch',
-                                                value: 'renameBranch',
-                                                action: 'Rename branch',
-                                        },
-                                        {
-                                                name: 'Reset',
-                                                value: 'reset',
-                                                action: 'Reset to commit',
-                                        },
-                                        {
-                                                name: 'Revert',
-                                                value: 'revert',
-                                                action: 'Revert commit',
-                                        },
-                                        {
-                                                name: 'Stash',
-                                                value: 'stash',
-                                                action: 'Stash changes',
-                                        },
-                                        {
-                                                name: 'Status',
-                                                value: 'status',
-                                                action: 'Show status',
-                                        },
-                                        {
-                                                name: 'Switch Branch',
-                                                value: 'switch',
-                                                action: 'Switch branch',
-                                        },
-                                        {
-                                                name: 'Tag',
-                                                value: 'tag',
-                                                action: 'Create tag',
-                                        },
-                                ],
-                                default: 'status',
-                        },
+				options: [
+					{
+						name: 'Add',
+						value: 'add',
+						action: 'Add files',
+					},
+					{
+						name: 'Apply Patch',
+						value: 'applyPatch',
+						action: 'Apply patch',
+					},
+					{
+						name: 'Branches',
+						value: 'branches',
+						action: 'List branches',
+					},
+					{
+						name: 'Checkout',
+						value: 'checkout',
+						action: 'Checkout',
+					},
+					{
+						name: 'Cherry Pick',
+						value: 'cherryPick',
+						action: 'Cherry pick commit',
+					},
+					{
+						name: 'Clone',
+						value: 'clone',
+						action: 'Clone repository',
+					},
+					{
+						name: 'Commit',
+						value: 'commit',
+						action: 'Create commit',
+					},
+					{
+						name: 'Commits',
+						value: 'commits',
+						action: 'List commits',
+					},
+					{
+						name: 'Create Branch',
+						value: 'createBranch',
+						action: 'Create branch',
+					},
+					{
+						name: 'Delete Branch',
+						value: 'deleteBranch',
+						action: 'Delete branch',
+					},
+					{
+						name: 'Fetch',
+						value: 'fetch',
+						action: 'Fetch from remote',
+					},
+					{
+						name: 'Init',
+						value: 'init',
+						action: 'Initialize repository',
+					},
+					{
+						name: 'Log',
+						value: 'log',
+						action: 'Show log',
+					},
+					{
+						name: 'Merge',
+						value: 'merge',
+						action: 'Merge branch',
+					},
+					{
+						name: 'Pull',
+						value: 'pull',
+						action: 'Pull branch',
+					},
+					{
+						name: 'Push',
+						value: 'push',
+						action: 'Push branch',
+					},
+					{
+						name: 'Rebase',
+						value: 'rebase',
+						action: 'Rebase branch',
+					},
+					{
+						name: 'Rename Branch',
+						value: 'renameBranch',
+						action: 'Rename branch',
+					},
+					{
+						name: 'Reset',
+						value: 'reset',
+						action: 'Reset to commit',
+					},
+					{
+						name: 'Revert',
+						value: 'revert',
+						action: 'Revert commit',
+					},
+					{
+						name: 'Stash',
+						value: 'stash',
+						action: 'Stash changes',
+					},
+					{
+						name: 'Status',
+						value: 'status',
+						action: 'Show status',
+					},
+					{
+						name: 'Switch Branch',
+						value: 'switch',
+						action: 'Switch branch',
+					},
+					{
+						name: 'Tag',
+						value: 'tag',
+						action: 'Create tag',
+					},
+				],
+				default: 'status',
+			},
 			{
 				displayName: 'Authentication',
 				name: 'authentication',
@@ -433,110 +443,108 @@ export class GitExtended implements INodeType {
 					},
 				},
 			},
-                        {
-                                displayName: 'Branch',
-                                name: 'branch',
-                                type: 'string',
-                                default: '',
-                                description: 'Branch name',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['push', 'pull', 'fetch'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'Branch Name',
-                                name: 'branchName',
-                                type: 'string',
-                                default: '',
-                                required: true,
-                                description: 'Name of the branch',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['createBranch', 'deleteBranch'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'Current Name',
-                                name: 'currentName',
-                                type: 'string',
-                                default: '',
-                                required: true,
-                                description: 'Current branch name',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['renameBranch'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'New Name',
-                                name: 'newName',
-                                type: 'string',
-                                default: '',
-                                required: true,
-                                description: 'New branch name',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['renameBranch'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'Upstream Branch',
-                                name: 'upstream',
-                                type: 'string',
-                                default: '',
-                                required: true,
-                                description: 'Branch to rebase onto',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['rebase'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'Commit ID',
-                                name: 'commit',
-                                type: 'string',
-                                default: '',
-                                required: true,
-                                description: 'Commit hash',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['cherryPick', 'revert', 'reset'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'Tag Name',
-                                name: 'tagName',
-                                type: 'string',
-                                default: '',
-                                required: true,
-                                description: 'Name of the tag',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['tag'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'Commit ID',
-                                name: 'tagCommit',
-                                type: 'string',
-                                default: '',
-                                description: 'Commit to tag, defaults to HEAD',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['tag'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'Patch Input',
+			{
+				displayName: 'Branch',
+				name: 'branch',
+				type: 'string',
+				default: '',
+				description: 'Branch name',
+				displayOptions: {
+					show: {
+						operation: ['push', 'pull', 'fetch'],
+					},
+				},
+			},
+			{
+				displayName: 'Branch Name',
+				name: 'branchName',
+				type: 'string',
+				default: '',
+				description: 'Name of the branch',
+				displayOptions: {
+					show: {
+						operation: ['createBranch', 'deleteBranch'],
+					},
+				},
+			},
+			{
+				displayName: 'Current Name',
+				name: 'currentName',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'Current branch name',
+				displayOptions: {
+					show: {
+						operation: ['renameBranch'],
+					},
+				},
+			},
+			{
+				displayName: 'New Name',
+				name: 'newName',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'New branch name',
+				displayOptions: {
+					show: {
+						operation: ['renameBranch'],
+					},
+				},
+			},
+			{
+				displayName: 'Upstream Branch',
+				name: 'upstream',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'Branch to rebase onto',
+				displayOptions: {
+					show: {
+						operation: ['rebase'],
+					},
+				},
+			},
+			{
+				displayName: 'Commit ID',
+				name: 'commit',
+				type: 'string',
+				default: '',
+				description: 'Commit hash',
+				displayOptions: {
+					show: {
+						operation: ['cherryPick', 'revert', 'reset'],
+					},
+				},
+			},
+			{
+				displayName: 'Tag Name',
+				name: 'tagName',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'Name of the tag',
+				displayOptions: {
+					show: {
+						operation: ['tag'],
+					},
+				},
+			},
+			{
+				displayName: 'Commit ID',
+				name: 'tagCommit',
+				type: 'string',
+				default: '',
+				description: 'Commit to tag, defaults to HEAD',
+				displayOptions: {
+					show: {
+						operation: ['tag'],
+					},
+				},
+			},
+			{
+				displayName: 'Patch Input',
 				name: 'patchInput',
 				type: 'options',
 				options: [
@@ -595,33 +603,33 @@ export class GitExtended implements INodeType {
 					},
 				},
 			},
-                        {
-                                displayName: 'Target',
-                                name: 'target',
-                                type: 'string',
-                                default: '',
-                                required: true,
-                                description: 'Branch or commit to operate on',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['switch', 'checkout', 'merge'],
-                                        },
-                                },
-                        },
-                        {
-                                displayName: 'Create',
-                                name: 'create',
-                                type: 'boolean',
-                                default: false,
-                                description: 'Whether to create the branch if it does not exist',
-                                displayOptions: {
-                                        show: {
-                                                operation: ['switch'],
-                                        },
-                                },
-                        },
-                ],
-        };
+			{
+				displayName: 'Target',
+				name: 'target',
+				type: 'string',
+				default: '',
+				required: true,
+				description: 'Branch or commit to operate on',
+				displayOptions: {
+					show: {
+						operation: ['switch', 'checkout', 'merge'],
+					},
+				},
+			},
+			{
+				displayName: 'Create',
+				name: 'create',
+				type: 'boolean',
+				default: false,
+				description: 'Whether to create the branch if it does not exist',
+				displayOptions: {
+					show: {
+						operation: ['switch'],
+					},
+				},
+			},
+		],
+	};
 
 	async execute(this: IExecuteFunctions): Promise<INodeExecutionData[][]> {
 		const items = this.getInputData();

--- a/test/gitExtended.test.js
+++ b/test/gitExtended.test.js
@@ -6,405 +6,484 @@ const os = require('os');
 const { GitExtended } = require('../dist/nodes/GitExtended/GitExtended.node.js');
 
 class TestContext {
-  constructor(parameters) {
-    this.parameters = parameters;
-  }
-  getInputData() {
-    return [{ json: {} }];
-  }
-  getNodeParameter(name) {
-    return this.parameters[name];
-  }
-  getNode() {
-    return { name: 'GitExtended' };
-  }
-  continueOnFail() {
-    return false;
-  }
+	constructor(parameters) {
+		this.parameters = parameters;
+	}
+	getInputData() {
+		return [{ json: {} }];
+	}
+	getNodeParameter(name) {
+		return this.parameters[name];
+	}
+	getNode() {
+		return { name: 'GitExtended' };
+	}
+	continueOnFail() {
+		return false;
+	}
 }
 
 test('init operation creates git repository', async () => {
-  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-test-'));
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'init', repoPath: tempDir });
-  await node.execute.call(context);
-  assert.ok(fs.existsSync(path.join(tempDir, '.git')));
-  fs.rmSync(tempDir, { recursive: true, force: true });
+	const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-test-'));
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'init', repoPath: tempDir });
+	await node.execute.call(context);
+	assert.ok(fs.existsSync(path.join(tempDir, '.git')));
+	fs.rmSync(tempDir, { recursive: true, force: true });
 });
 
 test('unsupported operation throws error', async () => {
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'unknown', repoPath: '.' });
-  await assert.rejects(async () => {
-    await node.execute.call(context);
-  }, /Unsupported operation/);
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'unknown', repoPath: '.' });
+	await assert.rejects(async () => {
+		await node.execute.call(context);
+	}, /Unsupported operation/);
 });
 
 test('clone operation clones repository', async () => {
-  const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-src-'));
-  const repoDir = path.join(sourceDir, 'repo');
-  fs.mkdirSync(repoDir);
-  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
-  require('child_process').execSync('git init', { cwd: repoDir });
-  // Configure git user for committing inside the test repository
-  require('child_process').execSync('git config user.email "test@example.com"', {
-    cwd: repoDir,
-  });
-  require('child_process').execSync('git config user.name "Test"', {
-    cwd: repoDir,
-  });
-  require('child_process').execSync('git add README.md', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+	const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-src-'));
+	const repoDir = path.join(sourceDir, 'repo');
+	fs.mkdirSync(repoDir);
+	fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+	require('child_process').execSync('git init', { cwd: repoDir });
+	// Configure git user for committing inside the test repository
+	require('child_process').execSync('git config user.email "test@example.com"', {
+		cwd: repoDir,
+	});
+	require('child_process').execSync('git config user.name "Test"', {
+		cwd: repoDir,
+	});
+	require('child_process').execSync('git add README.md', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
 
-  const cloneDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-clone-'));
-  const node = new GitExtended();
-  const targetPath = path.join(cloneDir, 'cloned');
-  const context = new TestContext({
-    operation: 'clone',
-    repoPath: cloneDir,
-    repoUrl: repoDir,
-    targetPath,
-  });
-  await node.execute.call(context);
-  assert.ok(fs.existsSync(path.join(targetPath, '.git')));
+	const cloneDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-clone-'));
+	const node = new GitExtended();
+	const targetPath = path.join(cloneDir, 'cloned');
+	const context = new TestContext({
+		operation: 'clone',
+		repoPath: cloneDir,
+		repoUrl: repoDir,
+		targetPath,
+	});
+	await node.execute.call(context);
+	assert.ok(fs.existsSync(path.join(targetPath, '.git')));
 
-  fs.rmSync(sourceDir, { recursive: true, force: true });
-  fs.rmSync(cloneDir, { recursive: true, force: true });
+	fs.rmSync(sourceDir, { recursive: true, force: true });
+	fs.rmSync(cloneDir, { recursive: true, force: true });
 });
 
 test('branches operation lists branches', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-branches-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', {
-    cwd: repoDir,
-  });
-  require('child_process').execSync('git config user.name "Test"', {
-    cwd: repoDir,
-  });
-  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
-  require('child_process').execSync('git add README.md', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
-  require('child_process').execSync('git branch feature', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-branches-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', {
+		cwd: repoDir,
+	});
+	require('child_process').execSync('git config user.name "Test"', {
+		cwd: repoDir,
+	});
+	fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+	require('child_process').execSync('git add README.md', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+	require('child_process').execSync('git branch feature', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'branches', repoPath: repoDir });
-  const result = await node.execute.call(context);
-  const output = result[0][0].json.stdout;
-  assert.ok(output.includes('feature'));
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'branches', repoPath: repoDir });
+	const result = await node.execute.call(context);
+	const output = result[0][0].json.stdout;
+	assert.ok(output.includes('feature'));
 
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('commits operation lists commits', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-commits-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', {
-    cwd: repoDir,
-  });
-  require('child_process').execSync('git config user.name "Test"', {
-    cwd: repoDir,
-  });
-  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
-  require('child_process').execSync('git add README.md', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'file.txt'), 'second');
-  require('child_process').execSync('git add file.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-commits-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', {
+		cwd: repoDir,
+	});
+	require('child_process').execSync('git config user.name "Test"', {
+		cwd: repoDir,
+	});
+	fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+	require('child_process').execSync('git add README.md', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'file.txt'), 'second');
+	require('child_process').execSync('git add file.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'commits', repoPath: repoDir });
-  const result = await node.execute.call(context);
-  const output = result[0][0].json.stdout;
-  assert.ok(output.includes('second'));
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'commits', repoPath: repoDir });
+	const result = await node.execute.call(context);
+	const output = result[0][0].json.stdout;
+	assert.ok(output.includes('second'));
 
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('createBranch operation creates branch', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-create-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
-  require('child_process').execSync('git add README.md', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-create-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+	require('child_process').execSync('git add README.md', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'createBranch', repoPath: repoDir, branchName: 'feature' });
-  await node.execute.call(context);
-  const branches = require('child_process').execSync('git branch', { cwd: repoDir }).toString();
-  assert.ok(branches.includes('feature'));
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({
+		operation: 'createBranch',
+		repoPath: repoDir,
+		branchName: 'feature',
+	});
+	await node.execute.call(context);
+	const branches = require('child_process').execSync('git branch', { cwd: repoDir }).toString();
+	assert.ok(branches.includes('feature'));
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('renameBranch operation renames branch', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-rename-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
-  require('child_process').execSync('git add README.md', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
-  require('child_process').execSync('git branch old', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-rename-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+	require('child_process').execSync('git add README.md', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+	require('child_process').execSync('git branch old', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'renameBranch', repoPath: repoDir, currentName: 'old', newName: 'new' });
-  await node.execute.call(context);
-  const branches = require('child_process').execSync('git branch', { cwd: repoDir }).toString();
-  assert.ok(branches.includes('new') && !branches.includes('old'));
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({
+		operation: 'renameBranch',
+		repoPath: repoDir,
+		currentName: 'old',
+		newName: 'new',
+	});
+	await node.execute.call(context);
+	const branches = require('child_process').execSync('git branch', { cwd: repoDir }).toString();
+	assert.ok(branches.includes('new') && !branches.includes('old'));
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('deleteBranch operation deletes branch', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-delete-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
-  require('child_process').execSync('git add README.md', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
-  require('child_process').execSync('git branch temp', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-delete-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+	require('child_process').execSync('git add README.md', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+	require('child_process').execSync('git branch temp', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'deleteBranch', repoPath: repoDir, branchName: 'temp' });
-  await node.execute.call(context);
-  const branches = require('child_process').execSync('git branch', { cwd: repoDir }).toString();
-  assert.ok(!branches.includes('temp'));
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({
+		operation: 'deleteBranch',
+		repoPath: repoDir,
+		branchName: 'temp',
+	});
+	await node.execute.call(context);
+	const branches = require('child_process').execSync('git branch', { cwd: repoDir }).toString();
+	assert.ok(!branches.includes('temp'));
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('switch operation can create branch', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-switch-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
-  require('child_process').execSync('git add README.md', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-switch-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+	require('child_process').execSync('git add README.md', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'switch', repoPath: repoDir, target: 'newbranch', create: true });
-  await node.execute.call(context);
-  const branch = require('child_process').execSync('git rev-parse --abbrev-ref HEAD', { cwd: repoDir }).toString().trim();
-  assert.strictEqual(branch, 'newbranch');
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({
+		operation: 'switch',
+		repoPath: repoDir,
+		target: 'newbranch',
+		create: true,
+	});
+	await node.execute.call(context);
+	const branch = require('child_process')
+		.execSync('git rev-parse --abbrev-ref HEAD', { cwd: repoDir })
+		.toString()
+		.trim();
+	assert.strictEqual(branch, 'newbranch');
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('stash operation stashes changes', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-stash-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'file.txt'), 'a');
-  require('child_process').execSync('git add file.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'file.txt'), 'b');
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-stash-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'file.txt'), 'a');
+	require('child_process').execSync('git add file.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'file.txt'), 'b');
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'stash', repoPath: repoDir });
-  await node.execute.call(context);
-  const status = require('child_process').execSync('git status --porcelain', { cwd: repoDir }).toString();
-  assert.strictEqual(status.trim(), '');
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'stash', repoPath: repoDir });
+	await node.execute.call(context);
+	const status = require('child_process')
+		.execSync('git status --porcelain', { cwd: repoDir })
+		.toString();
+	assert.strictEqual(status.trim(), '');
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('fetch operation fetches remote', async () => {
-  const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-remote-'));
-  require('child_process').execSync('git init --bare', { cwd: remoteDir });
+	const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-remote-'));
+	require('child_process').execSync('git init --bare', { cwd: remoteDir });
 
-  const pushDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-push-'));
-  require('child_process').execSync(`git clone ${remoteDir} .`, { cwd: pushDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: pushDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: pushDir });
-  fs.writeFileSync(path.join(pushDir, 'a.txt'), '1');
-  require('child_process').execSync('git add a.txt', { cwd: pushDir });
-  require('child_process').execSync('git commit -m "first"', { cwd: pushDir });
-  require('child_process').execSync('git push origin master', { cwd: pushDir });
+	const pushDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-push-'));
+	require('child_process').execSync(`git clone ${remoteDir} .`, { cwd: pushDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: pushDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: pushDir });
+	fs.writeFileSync(path.join(pushDir, 'a.txt'), '1');
+	require('child_process').execSync('git add a.txt', { cwd: pushDir });
+	require('child_process').execSync('git commit -m "first"', { cwd: pushDir });
+	require('child_process').execSync('git push origin master', { cwd: pushDir });
 
-  const localDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-local-'));
-  require('child_process').execSync(`git clone ${remoteDir} .`, { cwd: localDir });
+	const localDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-local-'));
+	require('child_process').execSync(`git clone ${remoteDir} .`, { cwd: localDir });
 
-  fs.writeFileSync(path.join(pushDir, 'b.txt'), '2');
-  require('child_process').execSync('git add b.txt', { cwd: pushDir });
-  require('child_process').execSync('git commit -m "second"', { cwd: pushDir });
-  require('child_process').execSync('git push origin master', { cwd: pushDir });
+	fs.writeFileSync(path.join(pushDir, 'b.txt'), '2');
+	require('child_process').execSync('git add b.txt', { cwd: pushDir });
+	require('child_process').execSync('git commit -m "second"', { cwd: pushDir });
+	require('child_process').execSync('git push origin master', { cwd: pushDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'fetch', repoPath: localDir, remote: 'origin' });
-  await node.execute.call(context);
-  const result = require('child_process').execSync('git rev-list origin/master --count', { cwd: localDir }).toString().trim();
-  assert.strictEqual(result, '2');
-  fs.rmSync(remoteDir, { recursive: true, force: true });
-  fs.rmSync(pushDir, { recursive: true, force: true });
-  fs.rmSync(localDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'fetch', repoPath: localDir, remote: 'origin' });
+	await node.execute.call(context);
+	const result = require('child_process')
+		.execSync('git rev-list origin/master --count', { cwd: localDir })
+		.toString()
+		.trim();
+	assert.strictEqual(result, '2');
+	fs.rmSync(remoteDir, { recursive: true, force: true });
+	fs.rmSync(pushDir, { recursive: true, force: true });
+	fs.rmSync(localDir, { recursive: true, force: true });
 });
 
 test('rebase operation rebases branch', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-rebase-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
-  require('child_process').execSync('git add a.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "base"', { cwd: repoDir });
-  require('child_process').execSync('git checkout -b feature', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'b.txt'), '2');
-  require('child_process').execSync('git add b.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "feature"', { cwd: repoDir });
-  require('child_process').execSync('git checkout master', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'c.txt'), '3');
-  require('child_process').execSync('git add c.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "master"', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-rebase-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
+	require('child_process').execSync('git add a.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "base"', { cwd: repoDir });
+	require('child_process').execSync('git checkout -b feature', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'b.txt'), '2');
+	require('child_process').execSync('git add b.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "feature"', { cwd: repoDir });
+	require('child_process').execSync('git checkout master', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'c.txt'), '3');
+	require('child_process').execSync('git add c.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "master"', { cwd: repoDir });
 
-  require('child_process').execSync('git checkout feature', { cwd: repoDir });
+	require('child_process').execSync('git checkout feature', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'rebase', repoPath: repoDir, upstream: 'master' });
-  await node.execute.call(context);
-  const log = require('child_process').execSync('git log --oneline', { cwd: repoDir }).toString();
-  assert.ok(log.split('\n')[0].includes('feature'));
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'rebase', repoPath: repoDir, upstream: 'master' });
+	await node.execute.call(context);
+	const log = require('child_process').execSync('git log --oneline', { cwd: repoDir }).toString();
+	assert.ok(log.split('\n')[0].includes('feature'));
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('cherryPick operation applies commit', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-cherry-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
-  require('child_process').execSync('git add a.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'b.txt'), '2');
-  require('child_process').execSync('git add b.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
-  const commit = require('child_process').execSync('git rev-parse HEAD', { cwd: repoDir }).toString().trim();
-  require('child_process').execSync('git reset --hard HEAD~1', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-cherry-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
+	require('child_process').execSync('git add a.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'b.txt'), '2');
+	require('child_process').execSync('git add b.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
+	const commit = require('child_process')
+		.execSync('git rev-parse HEAD', { cwd: repoDir })
+		.toString()
+		.trim();
+	require('child_process').execSync('git reset --hard HEAD~1', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'cherryPick', repoPath: repoDir, commit });
-  await node.execute.call(context);
-  const log = require('child_process').execSync('git log -1 --pretty=%B', { cwd: repoDir }).toString().trim();
-  assert.strictEqual(log, 'second');
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'cherryPick', repoPath: repoDir, commit });
+	await node.execute.call(context);
+	const log = require('child_process')
+		.execSync('git log -1 --pretty=%B', { cwd: repoDir })
+		.toString()
+		.trim();
+	assert.strictEqual(log, 'second');
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('revert operation reverts commit', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-revert-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
-  require('child_process').execSync('git add a.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'b.txt'), '2');
-  require('child_process').execSync('git add b.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
-  const commit = require('child_process').execSync('git rev-parse HEAD', { cwd: repoDir }).toString().trim();
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-revert-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
+	require('child_process').execSync('git add a.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'b.txt'), '2');
+	require('child_process').execSync('git add b.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
+	const commit = require('child_process')
+		.execSync('git rev-parse HEAD', { cwd: repoDir })
+		.toString()
+		.trim();
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'revert', repoPath: repoDir, commit });
-  await node.execute.call(context);
-  const log = require('child_process').execSync('git log -1 --pretty=%B', { cwd: repoDir }).toString();
-  assert.ok(log.includes('Revert'));
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'revert', repoPath: repoDir, commit });
+	await node.execute.call(context);
+	const log = require('child_process')
+		.execSync('git log -1 --pretty=%B', { cwd: repoDir })
+		.toString();
+	assert.ok(log.includes('Revert'));
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('reset operation resets to commit', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-reset-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
-  require('child_process').execSync('git add a.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'b.txt'), '2');
-  require('child_process').execSync('git add b.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
-  const first = require('child_process').execSync('git rev-list --max-parents=0 HEAD', { cwd: repoDir }).toString().trim();
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-reset-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
+	require('child_process').execSync('git add a.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'b.txt'), '2');
+	require('child_process').execSync('git add b.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "second"', { cwd: repoDir });
+	const first = require('child_process')
+		.execSync('git rev-list --max-parents=0 HEAD', { cwd: repoDir })
+		.toString()
+		.trim();
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'reset', repoPath: repoDir, commit: first });
-  await node.execute.call(context);
-  const head = require('child_process').execSync('git rev-parse HEAD', { cwd: repoDir }).toString().trim();
-  assert.strictEqual(head, first);
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'reset', repoPath: repoDir, commit: first });
+	await node.execute.call(context);
+	const head = require('child_process')
+		.execSync('git rev-parse HEAD', { cwd: repoDir })
+		.toString()
+		.trim();
+	assert.strictEqual(head, first);
+	fs.rmSync(repoDir, { recursive: true, force: true });
+});
+
+test('reset operation discards working changes', async () => {
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-reset-wd-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
+	require('child_process').execSync('git add a.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
+	const head = require('child_process')
+		.execSync('git rev-parse HEAD', { cwd: repoDir })
+		.toString()
+		.trim();
+	fs.writeFileSync(path.join(repoDir, 'a.txt'), '2');
+
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'reset', repoPath: repoDir });
+	await node.execute.call(context);
+
+	const headAfter = require('child_process')
+		.execSync('git rev-parse HEAD', { cwd: repoDir })
+		.toString()
+		.trim();
+	const status = require('child_process')
+		.execSync('git status --porcelain', { cwd: repoDir })
+		.toString()
+		.trim();
+	const content = fs.readFileSync(path.join(repoDir, 'a.txt'), 'utf8');
+
+	assert.strictEqual(headAfter, head);
+	assert.strictEqual(status, '');
+	assert.strictEqual(content, '1');
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('tag operation creates tag', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-tag-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
-  require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
-  fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
-  require('child_process').execSync('git add a.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-tag-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+	require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
+	require('child_process').execSync('git add a.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({ operation: 'tag', repoPath: repoDir, tagName: 'v1' });
-  await node.execute.call(context);
-  const tags = require('child_process').execSync('git tag', { cwd: repoDir }).toString();
-  assert.ok(tags.includes('v1'));
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({ operation: 'tag', repoPath: repoDir, tagName: 'v1' });
+	await node.execute.call(context);
+	const tags = require('child_process').execSync('git tag', { cwd: repoDir }).toString();
+	assert.ok(tags.includes('v1'));
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('checkout operation checks out branch', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-checkout-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', {
-    cwd: repoDir,
-  });
-  require('child_process').execSync('git config user.name "Test"', {
-    cwd: repoDir,
-  });
-  fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
-  require('child_process').execSync('git add a.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
-  require('child_process').execSync('git branch feature', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-checkout-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', {
+		cwd: repoDir,
+	});
+	require('child_process').execSync('git config user.name "Test"', {
+		cwd: repoDir,
+	});
+	fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
+	require('child_process').execSync('git add a.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
+	require('child_process').execSync('git branch feature', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({
-    operation: 'checkout',
-    repoPath: repoDir,
-    target: 'feature',
-  });
-  await node.execute.call(context);
-  const branch = require('child_process').execSync(
-    'git rev-parse --abbrev-ref HEAD',
-    { cwd: repoDir },
-  ).toString().trim();
-  assert.strictEqual(branch, 'feature');
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({
+		operation: 'checkout',
+		repoPath: repoDir,
+		target: 'feature',
+	});
+	await node.execute.call(context);
+	const branch = require('child_process')
+		.execSync('git rev-parse --abbrev-ref HEAD', { cwd: repoDir })
+		.toString()
+		.trim();
+	assert.strictEqual(branch, 'feature');
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });
 
 test('applyPatch operation applies patch', async () => {
-  const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-apply-'));
-  require('child_process').execSync('git init', { cwd: repoDir });
-  require('child_process').execSync('git config user.email "test@example.com"', {
-    cwd: repoDir,
-  });
-  require('child_process').execSync('git config user.name "Test"', {
-    cwd: repoDir,
-  });
-  fs.writeFileSync(path.join(repoDir, 'file.txt'), '1\n');
-  require('child_process').execSync('git add file.txt', { cwd: repoDir });
-  require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
+	const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-apply-'));
+	require('child_process').execSync('git init', { cwd: repoDir });
+	require('child_process').execSync('git config user.email "test@example.com"', {
+		cwd: repoDir,
+	});
+	require('child_process').execSync('git config user.name "Test"', {
+		cwd: repoDir,
+	});
+	fs.writeFileSync(path.join(repoDir, 'file.txt'), '1\n');
+	require('child_process').execSync('git add file.txt', { cwd: repoDir });
+	require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
 
-  fs.writeFileSync(path.join(repoDir, 'file.txt'), '2\n');
-  const patchText = require('child_process').execSync('git diff file.txt', {
-    cwd: repoDir,
-  }).toString();
-  require('child_process').execSync('git checkout -- file.txt', { cwd: repoDir });
+	fs.writeFileSync(path.join(repoDir, 'file.txt'), '2\n');
+	const patchText = require('child_process')
+		.execSync('git diff file.txt', {
+			cwd: repoDir,
+		})
+		.toString();
+	require('child_process').execSync('git checkout -- file.txt', { cwd: repoDir });
 
-  const node = new GitExtended();
-  const context = new TestContext({
-    operation: 'applyPatch',
-    repoPath: repoDir,
-    // The 'patchInput' parameter specifies the format of the patch. It is required by the GitExtended node.
-    patchInput: 'text',
-    patchText,
-  });
-  await node.execute.call(context);
-  const content = fs.readFileSync(path.join(repoDir, 'file.txt'), 'utf8').trim();
-  assert.strictEqual(content, '2');
-  fs.rmSync(repoDir, { recursive: true, force: true });
+	const node = new GitExtended();
+	const context = new TestContext({
+		operation: 'applyPatch',
+		repoPath: repoDir,
+		// The 'patchInput' parameter specifies the format of the patch. It is required by the GitExtended node.
+		patchInput: 'text',
+		patchText,
+	});
+	await node.execute.call(context);
+	const content = fs.readFileSync(path.join(repoDir, 'file.txt'), 'utf8').trim();
+	assert.strictEqual(content, '2');
+	fs.rmSync(repoDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- allow 'git reset --hard' without specifying a commit
- add test for discarding working tree changes

## Testing
- `npm run build`
- `npm test`