### PR TITLE
Add configUser operation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ These are the basic steps for working with the starter. For detailed guidance on
 
 ## Git Extended node
 
-This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, `createBranch`, `deleteBranch`, `renameBranch`, `commits`, `fetch`, `rebase`, `cherryPick`, `revert`, `reset`, `stash`, and `tag`.
+This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, `createBranch`, `deleteBranch`, `renameBranch`, `commits`, `fetch`, `rebase`, `cherryPick`, `revert`, `reset`, `stash`, `tag`, and `configUser`.
 The push operation includes a **Force Push** option that appends `--force` to the command when enabled.
 
 The *Remote* parameter accepts either a remote name (such as `origin`) or a full repository URL. This lets you push or pull from a configured remote or directly specify another repository.

--- a/test/gitExtended.test.js
+++ b/test/gitExtended.test.js
@@ -524,5 +524,30 @@ test('applyPatch operation applies patch', async () => {
 	await node.execute.call(context);
 	const content = fs.readFileSync(path.join(repoDir, 'file.txt'), 'utf8').trim();
 	assert.strictEqual(content, '2');
-	fs.rmSync(repoDir, { recursive: true, force: true });
+        fs.rmSync(repoDir, { recursive: true, force: true });
+});
+
+test('configUser operation sets user identity', async () => {
+        const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-auth-'));
+        require('child_process').execSync('git init', { cwd: repoDir });
+
+        const node = new GitExtended();
+        const context = new TestContext({
+                operation: 'configUser',
+                repoPath: repoDir,
+                userName: 'Test',
+                userEmail: 'test@example.com',
+        });
+        await node.execute.call(context);
+        const name = require('child_process')
+                .execSync('git config user.name', { cwd: repoDir })
+                .toString()
+                .trim();
+        const email = require('child_process')
+                .execSync('git config user.email', { cwd: repoDir })
+                .toString()
+                .trim();
+        assert.strictEqual(name, 'Test');
+        assert.strictEqual(email, 'test@example.com');
+        fs.rmSync(repoDir, { recursive: true, force: true });
 });


### PR DESCRIPTION
## Summary
- add `configUser` operation for setting git user.name and user.email
- document the new operation in README
- test the new operation

## Testing
- `npm run build`
- `npm test`