### PR TITLE
Fix empty commit failure

### DIFF
--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -78,12 +78,16 @@ const commandMap: Record<Operation, CommandBuilder> = {
 		const files = this.getNodeParameter('files', index) as string;
 		return { command: `git -C "${repoPath}" add ${files}` };
 	},
-	async [Operation.Commit](index, repoPath) {
-		const message = this.getNodeParameter('commitMessage', index) as string;
-		return {
-			command: `git -C "${repoPath}" commit -m "${message.replace(/"/g, '\\"')}"`,
-		};
-	},
+        async [Operation.Commit](index, repoPath) {
+                const message = this.getNodeParameter('commitMessage', index) as string;
+                const { stdout } = await exec(`git -C "${repoPath}" status --porcelain`);
+                if (stdout.trim() === '') {
+                        return { command: 'echo "No changes to commit"' };
+                }
+                return {
+                        command: `git -C "${repoPath}" commit -m "${message.replace(/"/g, '\\"')}"`,
+                };
+        },
         async [Operation.Push](index, repoPath) {
                 const remote = this.getNodeParameter('remote', index) as string;
                 const branch = this.getNodeParameter('branch', index) as string;

--- a/test/gitExtended.test.js
+++ b/test/gitExtended.test.js
@@ -551,3 +551,20 @@ test('configUser operation sets user identity', async () => {
         assert.strictEqual(email, 'test@example.com');
         fs.rmSync(repoDir, { recursive: true, force: true });
 });
+
+test('commit operation succeeds when there are no changes', async () => {
+        const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-empty-'));
+        require('child_process').execSync('git init', { cwd: repoDir });
+        require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+        require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+        fs.writeFileSync(path.join(repoDir, 'a.txt'), '1');
+        require('child_process').execSync('git add a.txt', { cwd: repoDir });
+        require('child_process').execSync('git commit -m "first"', { cwd: repoDir });
+
+        const node = new GitExtended();
+        const context = new TestContext({ operation: 'commit', repoPath: repoDir, commitMessage: 'empty' });
+        const [result] = await node.execute.call(context);
+        const output = result[0].json.stdout;
+        assert.ok(output.includes('No changes'));
+        fs.rmSync(repoDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- handle empty commits in Git Extended node
- test commit behavior when there are no changes

## Testing
- `npm run build`
- `npm test`
