### PR TITLE
Fix commit operation to stage unstaged files

### DIFF
--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -84,6 +84,15 @@ const commandMap: Record<Operation, CommandBuilder> = {
                 if (stdout.trim() === '') {
                         return { command: 'echo "No changes to commit"' };
                 }
+
+                // Stage all changed and untracked files so the commit succeeds
+                await exec(`git -C "${repoPath}" add -A`);
+
+                const { stdout: diff } = await exec(`git -C "${repoPath}" diff --cached --name-only`);
+                if (diff.trim() === '') {
+                        return { command: 'echo "No staged changes to commit"' };
+                }
+
                 return {
                         command: `git -C "${repoPath}" commit -m "${message.replace(/"/g, '\\"')}"`,
                 };


### PR DESCRIPTION
## Summary
- automatically stage changes in the commit operation
- test committing unstaged files

## Testing
- `npm run build`
- `npm test`