### PR TITLE
Implement Git LFS push support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ These are the basic steps for working with the starter. For detailed guidance on
 
 ## Git Extended node
 
-This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, `createBranch`, `deleteBranch`, `renameBranch`, `commits`, `fetch`, `rebase`, `cherryPick`, `revert`, `reset`, `stash`, `tag`, and `configUser`.
+This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `lfsPush`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, `createBranch`, `deleteBranch`, `renameBranch`, `commits`, `fetch`, `rebase`, `cherryPick`, `revert`, `reset`, `stash`, `tag`, and `configUser`.
 The push operation includes a **Force Push** option that appends `--force` to the command when enabled.
+Use `lfsPush` to manually upload Git LFS objects when the remote requires them.
 
 The *Remote* parameter accepts either a remote name (such as `origin`) or a full repository URL. This lets you push or pull from a configured remote or directly specify another repository.
 

--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -37,6 +37,7 @@ enum Operation {
         Tag = 'tag',
         Pull = 'pull',
         Push = 'push',
+        LfsPush = 'lfsPush',
         Status = 'status',
         Switch = 'switch',
         ConfigUser = 'configUser',
@@ -107,7 +108,15 @@ const commandMap: Record<Operation, CommandBuilder> = {
                 if (forcePush) cmd += ' --force';
                 return { command: cmd };
         },
-	async [Operation.Pull](index, repoPath) {
+        async [Operation.LfsPush](index, repoPath) {
+                const remote = this.getNodeParameter('remote', index) as string;
+                const branch = this.getNodeParameter('branch', index) as string;
+                let cmd = `git -C "${repoPath}" lfs push --all`;
+                if (remote) cmd += ` ${remote}`;
+                if (branch) cmd += ` ${branch}`;
+                return { command: cmd };
+        },
+        async [Operation.Pull](index, repoPath) {
 		const remote = this.getNodeParameter('remote', index) as string;
 		const branch = this.getNodeParameter('branch', index) as string;
 		let cmd = `git -C "${repoPath}" pull`;
@@ -317,31 +326,36 @@ export class GitExtended implements INodeType {
 						value: 'init',
 						action: 'Initialize repository',
 					},
-					{
-						name: 'Log',
-						value: 'log',
-						action: 'Show log',
-					},
-					{
-						name: 'Merge',
-						value: 'merge',
-						action: 'Merge branch',
-					},
+                                       {
+                                                name: 'LFS Push',
+                                                value: 'lfsPush',
+                                                action: 'Push git lfs objects',
+                                        },
+                                       {
+                                                name: 'Log',
+                                                value: 'log',
+                                                action: 'Show log',
+                                        },
+                                       {
+                                                name: 'Merge',
+                                                value: 'merge',
+                                                action: 'Merge branch',
+                                        },
 					{
 						name: 'Pull',
 						value: 'pull',
 						action: 'Pull branch',
 					},
-					{
-						name: 'Push',
-						value: 'push',
-						action: 'Push branch',
-					},
-					{
-						name: 'Rebase',
-						value: 'rebase',
-						action: 'Rebase branch',
-					},
+                                        {
+                                                name: 'Push',
+                                                value: 'push',
+                                                action: 'Push branch',
+                                        },
+                                       {
+                                                name: 'Rebase',
+                                                value: 'rebase',
+                                                action: 'Rebase branch',
+                                        },
 					{
 						name: 'Rename Branch',
 						value: 'renameBranch',
@@ -468,10 +482,10 @@ export class GitExtended implements INodeType {
 				description: 'Remote name',
 				displayOptions: {
 					show: {
-						operation: ['push', 'pull', 'fetch'],
-					},
-				},
-			},
+                                                operation: ['push', 'pull', 'fetch', 'lfsPush'],
+                                        },
+                                },
+                        },
                         {
                                 displayName: 'Branch',
                                 name: 'branch',
@@ -480,7 +494,7 @@ export class GitExtended implements INodeType {
                                 description: 'Branch name',
                                 displayOptions: {
                                         show: {
-                                                operation: ['push', 'pull', 'fetch'],
+                                                operation: ['push', 'pull', 'fetch', 'lfsPush'],
                                         },
                                 },
                         },

--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -329,7 +329,7 @@ export class GitExtended implements INodeType {
                                        {
                                                 name: 'LFS Push',
                                                 value: 'lfsPush',
-                                                action: 'Push git lfs objects',
+                                                action: 'Push Git LFS objects',
                                         },
                                        {
                                                 name: 'Log',

--- a/test/gitExtended.test.js
+++ b/test/gitExtended.test.js
@@ -586,3 +586,35 @@ test('commit operation stages unstaged files automatically', async () => {
         assert.ok(log.includes('second'));
         fs.rmSync(repoDir, { recursive: true, force: true });
 });
+
+test('lfsPush operation pushes LFS objects', async () => {
+        const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-lfs-src-'));
+        require('child_process').execSync('git init', { cwd: repoDir });
+        require('child_process').execSync('git lfs install --local', { cwd: repoDir });
+        require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+        require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+        require('child_process').execSync('git lfs track "*.bin"', { cwd: repoDir });
+        fs.writeFileSync(path.join(repoDir, 'file.bin'), 'data');
+        require('child_process').execSync('git add .gitattributes file.bin', { cwd: repoDir });
+        require('child_process').execSync('git commit -m "add"', { cwd: repoDir });
+
+        const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-lfs-remote-'));
+        require('child_process').execSync('git init --bare', { cwd: remoteDir });
+        require('child_process').execSync(`git remote add origin ${remoteDir}`, { cwd: repoDir });
+
+        const node = new GitExtended();
+        const context = new TestContext({
+                operation: 'lfsPush',
+                repoPath: repoDir,
+                remote: 'origin',
+                branch: 'master',
+        });
+        await node.execute.call(context);
+
+        const objectsPath = path.join(remoteDir, 'lfs/objects');
+        const hasObjects = fs.existsSync(objectsPath) && fs.readdirSync(objectsPath).length > 0;
+        assert.ok(hasObjects);
+
+        fs.rmSync(repoDir, { recursive: true, force: true });
+        fs.rmSync(remoteDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- add new `lfsPush` operation for pushing Git LFS objects
- document new operation in the README
- test `lfsPush` and expose parameters in node properties
- fix option ordering for lint compliance

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
