### PR TITLE
Add pushLfsObjects option

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ These are the basic steps for working with the starter. For detailed guidance on
 
 This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `lfsPush`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, `createBranch`, `deleteBranch`, `renameBranch`, `commits`, `fetch`, `rebase`, `cherryPick`, `revert`, `reset`, `stash`, `tag`, and `configUser`.
 The push operation includes a **Force Push** option that appends `--force` to the command when enabled.
+Enable **Push LFS Objects** to run `git lfs push --all` automatically before pushing.
 Use `lfsPush` to manually upload Git LFS objects when the remote requires them.
 
 The *Remote* parameter accepts either a remote name (such as `origin`) or a full repository URL. This lets you push or pull from a configured remote or directly specify another repository.

--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -102,7 +102,15 @@ const commandMap: Record<Operation, CommandBuilder> = {
                 const remote = this.getNodeParameter('remote', index) as string;
                 const branch = this.getNodeParameter('branch', index) as string;
                 const forcePush = this.getNodeParameter('forcePush', index, false) as boolean;
-                let cmd = `git -C "${repoPath}" push`;
+                const pushLfsObjects = this.getNodeParameter('pushLfsObjects', index, false) as boolean;
+                let cmd = '';
+                if (pushLfsObjects) {
+                        let lfsCmd = `git -C "${repoPath}" lfs push --all`;
+                        if (remote) lfsCmd += ` ${remote}`;
+                        if (branch) lfsCmd += ` ${branch}`;
+                        cmd += `${lfsCmd} && `;
+                }
+                cmd += `git -C "${repoPath}" push`;
                 if (remote) cmd += ` ${remote}`;
                 if (branch) cmd += ` ${branch}`;
                 if (forcePush) cmd += ' --force';
@@ -504,6 +512,19 @@ export class GitExtended implements INodeType {
                                 type: 'boolean',
                                 default: false,
                                 description: 'Whether to force push',
+                                displayOptions: {
+                                        show: {
+                                                operation: ['push'],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Push LFS Objects',
+                                name: 'pushLfsObjects',
+                                type: 'boolean',
+                                default: false,
+                                description:
+                                        'Run "git lfs push --all" before pushing to upload LFS objects',
                                 displayOptions: {
                                         show: {
                                                 operation: ['push'],

--- a/test/gitExtended.test.js
+++ b/test/gitExtended.test.js
@@ -618,3 +618,36 @@ test('lfsPush operation pushes LFS objects', async () => {
         fs.rmSync(repoDir, { recursive: true, force: true });
         fs.rmSync(remoteDir, { recursive: true, force: true });
 });
+
+test('push operation can push LFS objects', async () => {
+        const repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-lfs-src-'));
+        require('child_process').execSync('git init', { cwd: repoDir });
+        require('child_process').execSync('git lfs install --local', { cwd: repoDir });
+        require('child_process').execSync('git config user.email "test@example.com"', { cwd: repoDir });
+        require('child_process').execSync('git config user.name "Test"', { cwd: repoDir });
+        require('child_process').execSync('git lfs track "*.bin"', { cwd: repoDir });
+        fs.writeFileSync(path.join(repoDir, 'file.bin'), 'data');
+        require('child_process').execSync('git add .gitattributes file.bin', { cwd: repoDir });
+        require('child_process').execSync('git commit -m "add"', { cwd: repoDir });
+
+        const remoteDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-lfs-remote-'));
+        require('child_process').execSync('git init --bare', { cwd: remoteDir });
+        require('child_process').execSync(`git remote add origin ${remoteDir}`, { cwd: repoDir });
+
+        const node = new GitExtended();
+        const context = new TestContext({
+                operation: 'push',
+                repoPath: repoDir,
+                remote: 'origin',
+                branch: 'master',
+                pushLfsObjects: true,
+        });
+        await node.execute.call(context);
+
+        const objectsPath = path.join(remoteDir, 'lfs/objects');
+        const hasObjects = fs.existsSync(objectsPath) && fs.readdirSync(objectsPath).length > 0;
+        assert.ok(hasObjects);
+
+        fs.rmSync(repoDir, { recursive: true, force: true });
+        fs.rmSync(remoteDir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Summary
- support pushing Git LFS objects as part of push
- document the new option
- test push with LFS objects

## Testing
- `npm run build`
- `npm test`