### PR TITLE
Add skip LFS push option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ These are the basic steps for working with the starter. For detailed guidance on
 This repository includes a Git Extended node located in `/nodes/GitExtended`. It lets you execute common Git commands inside your workflows. The node supports operations like `clone`, `init`, `add`, `commit`, `push`, `lfsPush`, `pull`, `status`, `log`, `switch`, `checkout`, `merge`, `applyPatch`, `branches`, `createBranch`, `deleteBranch`, `renameBranch`, `commits`, `fetch`, `rebase`, `cherryPick`, `revert`, `reset`, `stash`, `tag`, and `configUser`.
 The push operation includes a **Force Push** option that appends `--force` to the command when enabled.
 Enable **Push LFS Objects** to run `git lfs push --all` automatically before pushing.
+Enable **Skip LFS Push** to set `GIT_LFS_SKIP_PUSH=1` and skip uploading LFS objects during the push.
 Use `lfsPush` to manually upload Git LFS objects when the remote requires them.
 
 The *Remote* parameter accepts either a remote name (such as `origin`) or a full repository URL. This lets you push or pull from a configured remote or directly specify another repository.

--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -101,20 +101,22 @@ const commandMap: Record<Operation, CommandBuilder> = {
         async [Operation.Push](index, repoPath) {
                 const remote = this.getNodeParameter('remote', index) as string;
                 const branch = this.getNodeParameter('branch', index) as string;
-                const forcePush = this.getNodeParameter('forcePush', index, false) as boolean;
-                const pushLfsObjects = this.getNodeParameter('pushLfsObjects', index, false) as boolean;
-                let cmd = '';
-                if (pushLfsObjects) {
-                        let lfsCmd = `git -C "${repoPath}" lfs push --all`;
-                        if (remote) lfsCmd += ` ${remote}`;
-                        if (branch) lfsCmd += ` ${branch}`;
-                        cmd += `${lfsCmd} && `;
-                }
-                cmd += `git -C "${repoPath}" push`;
-                if (remote) cmd += ` ${remote}`;
-                if (branch) cmd += ` ${branch}`;
-                if (forcePush) cmd += ' --force';
-                return { command: cmd };
+               const forcePush = this.getNodeParameter('forcePush', index, false) as boolean;
+               const pushLfsObjects = this.getNodeParameter('pushLfsObjects', index, false) as boolean;
+               const skipLfsPush = this.getNodeParameter('skipLfsPush', index, false) as boolean;
+               let cmd = '';
+               if (pushLfsObjects) {
+                       let lfsCmd = `git -C "${repoPath}" lfs push --all`;
+                       if (remote) lfsCmd += ` ${remote}`;
+                       if (branch) lfsCmd += ` ${branch}`;
+                       cmd += `${lfsCmd} && `;
+               }
+               cmd += `git -C "${repoPath}" push`;
+               if (remote) cmd += ` ${remote}`;
+               if (branch) cmd += ` ${branch}`;
+               if (forcePush) cmd += ' --force';
+               if (skipLfsPush) cmd = `GIT_LFS_SKIP_PUSH=1 ${cmd}`;
+               return { command: cmd };
         },
         async [Operation.LfsPush](index, repoPath) {
                 const remote = this.getNodeParameter('remote', index) as string;
@@ -525,6 +527,18 @@ export class GitExtended implements INodeType {
                                 default: false,
                                description:
                                        'Whether to run "git lfs push --all" before pushing to upload LFS objects',
+                                displayOptions: {
+                                        show: {
+                                                operation: ['push'],
+                                        },
+                                },
+                        },
+                        {
+                                displayName: 'Skip LFS Push',
+                                name: 'skipLfsPush',
+                                type: 'boolean',
+                                default: false,
+                                description: 'Whether to set GIT_LFS_SKIP_PUSH=1 to avoid uploading LFS objects',
                                 displayOptions: {
                                         show: {
                                                 operation: ['push'],


### PR DESCRIPTION
## Summary
- add `skipLfsPush` parameter to Git Extended node
- document how to skip LFS objects in README
- test skipping LFS objects during push

## Testing
- `npm run build`
- `npm run lint`
- `npm test`