### PR TITLE
Add skipStdout checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ The push operation includes a **Force Push** option that appends `--force` to th
 Enable **Push LFS Objects** to run `git lfs push --all` automatically before pushing.
 Enable **Skip LFS Push** to set `GIT_LFS_SKIP_PUSH=1` and skip uploading LFS objects during the push.
 Use `lfsPush` to manually upload Git LFS objects when the remote requires them.
+Enable **Skip Stdout** to discard command output and avoid `stdout maxBuffer length exceeded` errors when commands produce large output. When enabled, the commit operation skips status checks and stages files directly.
 
 The *Remote* parameter accepts either a remote name (such as `origin`) or a full repository URL. This lets you push or pull from a configured remote or directly specify another repository.
 


### PR DESCRIPTION
## Summary
- handle `skipStdout` in commit operation and run commands without capturing output
- add helper `runCommand` for optional stdout capture
- document that commit skips status checks when skipping stdout

## Testing
- `npm run lint`
- `npm run build`
- `npm test`
