### PR TITLE
Add custom git auth option

### DIFF
--- a/nodes/GitExtended/GitExtended.node.ts
+++ b/nodes/GitExtended/GitExtended.node.ts
@@ -67,15 +67,21 @@ type CommandBuilder = (
 const commandMap: Record<Operation, CommandBuilder> = {
 	async [Operation.Clone](index, repoPath) {
 		let repoUrl = this.getNodeParameter('repoUrl', index) as string;
-		const auth = this.getNodeParameter('authentication', index) as string;
-		if (auth === 'gitExtendedApi') {
-			const creds = await this.getCredentials('gitExtendedApi');
-			try {
-				const url = new URL(repoUrl);
-				url.username = creds.username as string;
-				url.password = creds.password as string;
-				repoUrl = url.toString();
-			} catch (error) {
+               const auth = this.getNodeParameter('authentication', index) as string;
+               if (auth === 'gitExtendedApi' || auth === 'custom') {
+                       const creds =
+                               auth === 'gitExtendedApi'
+                                       ? await this.getCredentials('gitExtendedApi')
+                                       : {
+                                               username: this.getNodeParameter('customUsername', index) as string,
+                                               password: this.getNodeParameter('customPassword', index) as string,
+                                       };
+                       try {
+                               const url = new URL(repoUrl);
+                               url.username = creds.username as string;
+                               url.password = creds.password as string;
+                               repoUrl = url.toString();
+                       } catch (error) {
 				throw new NodeOperationError(
 					this.getNode(),
 					`Failed to parse the repository URL: ${repoUrl}. Error: ${(error as Error).message}`,
@@ -112,8 +118,26 @@ const commandMap: Record<Operation, CommandBuilder> = {
                 };
         },
         async [Operation.Push](index, repoPath) {
-                const remote = this.getNodeParameter('remote', index) as string;
-                const branch = this.getNodeParameter('branch', index) as string;
+               let remote = this.getNodeParameter('remote', index) as string;
+               const branch = this.getNodeParameter('branch', index) as string;
+               const auth = this.getNodeParameter('authentication', index) as string;
+               if (remote) {
+                       try {
+                               if (auth === 'gitExtendedApi' || auth === 'custom') {
+                                       const creds =
+                                               auth === 'gitExtendedApi'
+                                                       ? await this.getCredentials('gitExtendedApi')
+                                                       : {
+                                                               username: this.getNodeParameter('customUsername', index) as string,
+                                                               password: this.getNodeParameter('customPassword', index) as string,
+                                                       };
+                                       const url = new URL(remote);
+                                       url.username = creds.username as string;
+                                       url.password = creds.password as string;
+                                       remote = url.toString();
+                               }
+                       } catch {}
+               }
                const forcePush = this.getNodeParameter('forcePush', index, false) as boolean;
                const pushLfsObjects = this.getNodeParameter('pushLfsObjects', index, false) as boolean;
                const skipLfsPush = this.getNodeParameter('skipLfsPush', index, false) as boolean;
@@ -140,12 +164,30 @@ const commandMap: Record<Operation, CommandBuilder> = {
                 return { command: cmd };
         },
         async [Operation.Pull](index, repoPath) {
-		const remote = this.getNodeParameter('remote', index) as string;
-		const branch = this.getNodeParameter('branch', index) as string;
-		let cmd = `git -C "${repoPath}" pull`;
-		if (remote) cmd += ` ${remote}`;
-		if (branch) cmd += ` ${branch}`;
-		return { command: cmd };
+               let remote = this.getNodeParameter('remote', index) as string;
+               const branch = this.getNodeParameter('branch', index) as string;
+               const auth = this.getNodeParameter('authentication', index) as string;
+               if (remote) {
+                       try {
+                               if (auth === 'gitExtendedApi' || auth === 'custom') {
+                                       const creds =
+                                               auth === 'gitExtendedApi'
+                                                       ? await this.getCredentials('gitExtendedApi')
+                                                       : {
+                                                               username: this.getNodeParameter('customUsername', index) as string,
+                                                               password: this.getNodeParameter('customPassword', index) as string,
+                                                       };
+                                       const url = new URL(remote);
+                                       url.username = creds.username as string;
+                                       url.password = creds.password as string;
+                                       remote = url.toString();
+                               }
+                       } catch {}
+               }
+               let cmd = `git -C "${repoPath}" pull`;
+               if (remote) cmd += ` ${remote}`;
+               if (branch) cmd += ` ${branch}`;
+               return { command: cmd };
 	},
 	async [Operation.Branches](_index, repoPath) {
 		return { command: `git -C "${repoPath}" branch` };
@@ -421,26 +463,57 @@ export class GitExtended implements INodeType {
 				displayName: 'Authentication',
 				name: 'authentication',
 				type: 'options',
-				options: [
-					{
-						name: 'Authenticate',
-						value: 'gitExtendedApi',
-					},
-					{
-						name: 'None',
-						value: 'none',
-					},
-				],
+                               options: [
+                                       {
+                                               name: 'Authenticate',
+                                               value: 'gitExtendedApi',
+                                       },
+                                       {
+                                               name: 'Custom',
+                                               value: 'custom',
+                                       },
+                                       {
+                                               name: 'None',
+                                               value: 'none',
+                                       },
+                               ],
 				displayOptions: {
 					show: {
 						operation: ['clone', 'push', 'pull'],
 					},
 				},
-				default: 'none',
-				description: 'The way to authenticate',
-			},
-			{
-				displayName: 'Repository Path',
+                                default: 'none',
+                                description: 'The way to authenticate',
+                        },
+                        {
+                                displayName: 'Username',
+                                name: 'customUsername',
+                                type: 'string',
+                                default: '',
+                                displayOptions: {
+                                        show: {
+                                                authentication: ['custom'],
+                                                operation: ['clone', 'push', 'pull'],
+                                        },
+                                },
+                                description: 'Username for custom authentication',
+                        },
+                        {
+                                displayName: 'Password',
+                                name: 'customPassword',
+                                type: 'string',
+                                typeOptions: { password: true },
+                                default: '',
+                                displayOptions: {
+                                        show: {
+                                                authentication: ['custom'],
+                                                operation: ['clone', 'push', 'pull'],
+                                        },
+                                },
+                                description: 'Password for custom authentication',
+                        },
+                        {
+                                displayName: 'Repository Path',
 				name: 'repoPath',
 				type: 'string',
 				default: '.',

--- a/test/gitExtended.test.js
+++ b/test/gitExtended.test.js
@@ -68,8 +68,43 @@ test('clone operation clones repository', async () => {
 	await node.execute.call(context);
 	assert.ok(fs.existsSync(path.join(targetPath, '.git')));
 
-	fs.rmSync(sourceDir, { recursive: true, force: true });
-	fs.rmSync(cloneDir, { recursive: true, force: true });
+        fs.rmSync(sourceDir, { recursive: true, force: true });
+        fs.rmSync(cloneDir, { recursive: true, force: true });
+});
+
+test('clone operation supports custom authentication', async () => {
+        const sourceDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-src-'));
+        const repoDir = path.join(sourceDir, 'repo');
+        fs.mkdirSync(repoDir);
+        fs.writeFileSync(path.join(repoDir, 'README.md'), 'hello');
+        require('child_process').execSync('git init', { cwd: repoDir });
+        require('child_process').execSync('git config user.email "test@example.com"', {
+                cwd: repoDir,
+        });
+        require('child_process').execSync('git config user.name "Test"', {
+                cwd: repoDir,
+        });
+        require('child_process').execSync('git add README.md', { cwd: repoDir });
+        require('child_process').execSync('git commit -m "init"', { cwd: repoDir });
+
+        const cloneDir = fs.mkdtempSync(path.join(os.tmpdir(), 'git-ext-clone-'));
+        const node = new GitExtended();
+        const targetPath = path.join(cloneDir, 'cloned');
+        const repoUrl = `file://${repoDir}`;
+        const context = new TestContext({
+                operation: 'clone',
+                repoPath: cloneDir,
+                repoUrl,
+                targetPath,
+                authentication: 'custom',
+                customUsername: 'u',
+                customPassword: 'p',
+        });
+        await node.execute.call(context);
+        assert.ok(fs.existsSync(path.join(targetPath, '.git')));
+
+        fs.rmSync(sourceDir, { recursive: true, force: true });
+        fs.rmSync(cloneDir, { recursive: true, force: true });
 });
 
 test('branches operation lists branches', async () => {


### PR DESCRIPTION
## Summary
- test: add case for custom auth
- feat: allow custom git auth with username/password fields

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685766ca0144832ba364acb20a4b6181